### PR TITLE
Add missing GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical GitHub collaboration and coding skills",
+        "schedule": "Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
Adds the missing "GitHub Skills" activity to the in-memory activities list so it appears in the signup UI.

## Changes
- Added a new GitHub Skills entry in src/app.py
- Included description, schedule, max participants, and empty participants list

## Why
Closes the gap reported in issue #6 where students could not find the announced activity.

Closes #6